### PR TITLE
Add Combobox field type

### DIFF
--- a/front/object.form.php
+++ b/front/object.form.php
@@ -82,6 +82,15 @@ if (!is_null($itemtype)) {
       }
    } else if (isset ($_POST["update"])) {
       $item->check($id, UPDATE);
+      //Use case: Comboboxes with no value selected are not posted as part of a form's data.
+      //          Assigning an empty array to these missing fields will update the database.
+      //          This logic only applies when receiving data from HTML forms.
+      $_POST = call_user_func(
+         [$item, 'fillMissingKeys'],
+         $_POST,
+         $item->listComboboxFields(),
+         []
+      );
       $item->update($_POST);
       Html::back();
    } else if (isset ($_POST["restore"])) {

--- a/inc/field.class.php
+++ b/inc/field.class.php
@@ -384,6 +384,9 @@ class PluginGenericobjectField extends CommonDBTM {
             case 'decimal' :
                $query .= "DECIMAL(20,4) NOT NULL DEFAULT '0.0000'";
                break;
+            case 'combobox' :
+               $query .= "JSON NULL";
+               break;
          }
          if ($after) {
             $query.=" AFTER `$after`";

--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -664,9 +664,10 @@ class PluginGenericobjectObject extends CommonDBTM {
                $values = is_array($values) ? $values : [];
 
                //Display combobox
+               asort($elements);
                Dropdown::showFromArray(
                   $name,
-                  asort($elements),
+                  $elements,
                   [
                      'display' => true,
                      'multiple' => true,

--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -1273,4 +1273,103 @@ class PluginGenericobjectObject extends CommonDBTM {
       return $menu;
    }
 
+    /**
+    * Given an associative array of field-value pairs, serialize all combobox fields.
+    * Use case: Serialize combobox fields values from array to string.
+    *
+    * @param   array   $data
+    * @return  array   The potentially modified data array
+    **/
+   public function serializeAllComboboxInputs($data) {
+      foreach ($this->listComboboxFields() as $name) {
+         if (isset($data[$name])) {
+            $data[$name] = $this->serializeComboboxField($data[$name]);
+         }
+      }   
+      return $data;
+   }
+
+   /**
+    * Given an associative array of field-value pairs, deserialize all combobox fields.
+    * Use case: Deserialize combobox fields values from string to array.
+    *
+    * @param   array   $data
+    * @return  array   A potentially modified data array
+    * @todo Code a function to get the list of all combobox fields.
+    **/
+   public function deSerializeAllComboboxInputs($data) {
+      foreach ($this->listComboboxFields() as $name) {
+         if (isset($data[$name])) {
+            $data[$name] = $this->deSerializeComboboxField($data[$name]);
+         }
+      }   
+      return $data;
+   }
+
+   /**
+    * Get a list of all combobox fields.
+    *
+    * @return  array   A list of field names.
+    **/
+   public function listComboboxFields() {
+      return PluginGenericobjectType::listFieldsByInputType(get_called_class(), 'combobox');
+   }
+
+   /**
+    * Serialize an input field of type Combobox before saving into database.
+    *
+    * @param   array   $value An array to serialize
+    * @return  string   A serialized value
+    * @throws  Exception
+    **/
+   public function serializeComboboxField($value) {
+      if ( ! is_array($value)) {
+         throw new Exception('Usage: Parameter "value" must be of type array.');
+      }
+      
+      $value = json_encode($value);
+      
+      if ( ! is_string($value)) {
+         throw new Exception('Serialization error: '.json_last_error_msg());
+      }
+      
+      return $value;
+   }
+
+   /**
+    * Deserialize an input field of type Combobox read from database.
+    *
+    * @param   string/null   $value A serialized value
+    * @return  array   A deserialized value
+    **/
+   public function deserializeComboboxField($value) {
+      //Value from DB may be null or an empty string, else assume it's a valid json string.
+      $value = is_string($value) && strlen($value) > 0 ? json_decode($value) : [];
+      
+      if ( ! is_array($value)) {
+         throw new Exception('Invalid value or deserialization error: '.json_last_error_msg());
+      }
+      
+      return $value;
+   }
+
+   /**
+    * Add a key-value pair for any field name that is not a key in data.
+    * Use case: Adding a default value in $_POST array when combobox is empty.
+    *
+    * @param   array   $data     An associative map of field-value pairs
+    * @param   array   $fields   A list of field names
+    * @param   mixed   $value    The value to associate to missing fields.
+    * 
+    * @return  array   A potentially modified data array.
+    **/
+   public static function fillMissingKeys($data, $fields, $value) {
+      foreach ($fields as $name) {
+         if ( ! isset($data[$name])) {
+            $data[$name] = $value;
+         }
+      }
+      return $data;
+   }
+
 }

--- a/inc/object.class.php
+++ b/inc/object.class.php
@@ -660,8 +660,7 @@ class PluginGenericobjectObject extends CommonDBTM {
                }
 
                //List selected values
-               $values = json_decode($value);
-               $values = is_array($values) ? $values : [];
+               $values = $this->deserializeComboboxField($value);
 
                //Display combobox
                asort($elements);
@@ -768,6 +767,8 @@ class PluginGenericobjectObject extends CommonDBTM {
       unset ($input['id']);
       unset ($input['withtemplate']);
 
+      $input = $this->serializeAllComboboxInputs($input);
+
       return $input;
    }
 
@@ -797,6 +798,17 @@ class PluginGenericobjectObject extends CommonDBTM {
       }
    }
 
+   /**
+    * Prepare input datas for updating the item
+    *
+    * @param array $input data used to update the item
+    *
+    * @return array the modified $input array
+   **/
+   function prepareInputForUpdate($input) {
+      $input = $this->serializeAllComboboxInputs($input);
+      return $input;
+   }
 
    function cleanDBonPurge() {
       $parameters = ['items_id' => $this->getID(), 'itemtype' => get_called_class()];

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -1752,6 +1752,36 @@ class PluginGenericobjectType extends CommonDBTM {
       return $associated_tables;
    }
 
+   /**
+    * Get all fields of a given input type and item type.
+    * Note: Copied and adapted from method getDropdownForItemtype.
+    * 
+    * @param   string  item_type    the itemtype
+    * @param   string  input_type   The input type (as specified in itemtype.constant.php files)
+    * 
+    * @return an array of field names
+    */
+   static function listFieldsByInputType($item_type, $input_type) {
+      global $DB;
+      $retval = [];
+      if (class_exists($item_type)) {
+         $source_table = getTableForItemType($item_type);
+         foreach (PluginGenericobjectSingletonObjectField::getInstance($item_type)
+                  as $field => $value) {
+            //Will use table name to make sure GenericObject (GO) owns the field.
+            $table = getTableNameForForeignKeyField($field);
+            $options = PluginGenericobjectField::getFieldOptions($field, $item_type);
+            if (isset($options['input_type'])
+               and strtolower($options['input_type']) === strtolower($input_type)
+               and preg_match('/^glpi_plugin_genericobject/', $table)//GO must own the field.
+            ) {
+               $retval[] = $field;
+            }
+         }
+      }
+
+      return $retval;
+   }
 
    static function deleteDropdownsForItemtype($itemtype) {
       global $DB;

--- a/inc/type.class.php
+++ b/inc/type.class.php
@@ -1742,7 +1742,7 @@ class PluginGenericobjectType extends CommonDBTM {
             $table = getTableNameForForeignKeyField($field);
             $options = PluginGenericobjectField::getFieldOptions($field, $itemtype);
             if (isset($options['input_type'])
-               and $options['input_type'] === 'dropdown'
+               and ($options['input_type'] === 'dropdown' OR $options['input_type'] === 'combobox')
                and preg_match('/^glpi_plugin_genericobject/', $table)
             ) {
                $associated_tables[] = $table;


### PR DESCRIPTION
Add a field type that allows the user to select multiple values taken from a dropdown (a.k.a. a combobox). This is related to issue #76

### Usage instructions
1. In constant.php file, define the field as you would for a (custom) dropdown.
2. But use "combobox" as itemtype.
3. Option "is_tree" should be set to false for now, as it was not yet tested with true.

### Tested OK for this scenario
A combobox field declared in an itemtype.constant.php file and that refers to a dropdown whose table name begins with "glpi_plugin_genericobject_".

### Attention
Don't forget that field names (DB table column name) must never exceed 64 characters. If the name is too long, then the field won't be added to the object's table and you won't get much feedback from GLPI.

### TODO
1. Test with field option ['is_tree'] = true.
2. Test with global field (defined in field.constant.php instead of itemtype.constant.php).
3. Test using dropdowns not created with GenericObject (i.e.: standard GLPI dropdowns that refer to DB tables with names that don't begin with "glpi_plugin_genericobject").
4. Add importation logic. May require changes in DataInjection templates managed by GenericObject.
